### PR TITLE
Add reporting domain warning

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,7 +184,7 @@
 <li>
     <div class="uk-margin">
         <p>{{ text.result }}</p>
-
+        <div class="uk-alert uk-alert-warning" v-if="reporting_domain !== ''">{{ text.ruf_rua_warning }} <strong>{{ reporting_domain }}</strong></div>
         <hr>
 
         <pre>{{ dmarc }}</pre>

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -6,6 +6,7 @@ var app = new Vue({
         pct: 100,
         aspf: 'r',
         adkim: 'r',
+        reporting_domain: '',
         rua: '',
         ri: '86400',
         ruf: '',
@@ -108,8 +109,18 @@ var app = new Vue({
         showHelp: function(help) {
             this.help = help;
         },
+        update_reporting_domain: function(value) {
+            var match = /@(.+)$/.exec(value);
+            if (match) {
+                this.reporting_domain = match[1];
+            }
+        },
     },
     mounted: function() {
         this.translate(this.lang);
+    },
+    watch: {
+        ruf: 'update_reporting_domain',
+        rua: 'update_reporting_domain',
     },
 })

--- a/static/js/lang/en.json
+++ b/static/js/lang/en.json
@@ -28,6 +28,7 @@
     "p_rf": "Report format",
     "p_rf_afrf": "X-ARF format",
     "p_rf_iodef": "XML format",
+    "ruf_rua_warning": "The TXT record shown below is only valid for",
     "w_copy": "copy",
     "w_hour": "hour",
     "w_hours": "hours",

--- a/static/js/lang/nl.json
+++ b/static/js/lang/nl.json
@@ -28,6 +28,7 @@
     "p_rf": "Rapport-formaat",
     "p_rf_afrf": "X-ARF-formaat",
     "p_rf_iodef": "XML-formaat",
+    "ruf_rua_warning": "Let op: het TXT record hieronder is alleen geldig voor",
     "w_copy": "kopiëren",
     "w_hour": "uur",
     "w_hours": "uur",


### PR DESCRIPTION
Warn the user that the generated TXT record is only valid for the
domain listed in rua/ruf.
![Screen Shot 2022-02-10 at 10 05 01](https://user-images.githubusercontent.com/171494/153374097-50034285-fbd6-4269-8910-93bc91ee7e3d.png)

Closes #1 

